### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ app.use(vueHljs, { hljs })
 
 This plugin use gruvbox-dark as default style.
 
-You can wirte your own style or see [highlight.js demo](https://highlightjs.org/static/demo/).
+You can write your own style or see [highlight.js demo](https://highlightjs.org/static/demo/).
 And then import your css file in Vue project entry.
 
 ## Other similar project


### PR DESCRIPTION
## Summary
- fix a typo in README

## Testing
- `yarn test` *(fails: package doesn't seem to be present in your lockfile)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9534b6a4832580ba2d1b16e00423