### PR TITLE
Fix incorrect package export paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "3.0.1",
   "description": "Highlight.js plugin for Vue.js 3.0",
   "main": "./dist/vue-hljs.umd.js",
-  "module": "./dist/vue-hljs.es.js",
+  "module": "./dist/vue-hljs.mjs",
   "exports": {
     ".": {
-      "import": "./dist/my-lib.es.js",
-      "require": "./dist/my-lib.umd.js"
+      "import": "./dist/vue-hljs.mjs",
+      "require": "./dist/vue-hljs.umd.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary
- correct the `module` and `exports` paths in `package.json`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f949a69088325bc8f21f85b4a4cf5