### PR TITLE
Fix README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,6 @@ This plugin use gruvbox-dark as default style.
 You can wirte your own style or see [highlight.js demo](https://highlightjs.org/static/demo/).
 And then import your css file in Vue project entry.
 
-## Other similar project
+## Other similar projects
 
 - [highlightjs/vue-plugin](https://github.com/highlightjs/vue-plugin): Highlight.js official plugin.


### PR DESCRIPTION
## Summary
- correct header pluralization in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f955538248325b24ff45eae9073a5