### PR TITLE
Fix tests for directives

### DIFF
--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -22,6 +22,6 @@ describe.concurrent('setup', () => {
   })
 
   it('app instance has highlight directive', (t) => {
-    expect(app.directive('highlight')).toBeTruthy()
+    expect(app.directive('highlight')).toBeDefined()
   })
 })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import hljs from 'highlight.js'
 import plugin from '../dist/vue-hljs.umd'
 import { createApp } from 'vue'
@@ -18,10 +18,10 @@ app.use(plugin, { hljs })
 // test case
 describe.concurrent('setup', () => {
   it('vueHljs.install is function', (t) => {
-    return plugin.install instanceof Function
+    expect(plugin.install).toBeInstanceOf(Function)
   })
 
   it('app instance has highlight directive', (t) => {
-    return 'highlight' in app.directive
+    expect(app.directive('highlight')).toBeTruthy()
   })
 })


### PR DESCRIPTION
## Summary
- use `expect` instead of returning booleans in `test/main.test.ts`
- check directive registration via `app.directive('highlight')`

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_683f959400248325a5ac248c9b29a032